### PR TITLE
Double slashed Windows paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,9 @@ How to install (Windows)
 * Install Python 2.7 (http://python.org)
 * Install Cython (Windows binaries on http://cython.org/#download)
 * Install Microsoft Visual Studio 2008 Express
-* Add "C:\Program Files (x86)\Microsoft Visual Studio 9.0" to system PATH
+* Add "C:\\Program Files (x86)\\Microsoft Visual Studio 9.0" to system PATH
 * Clone repository (using TortoiseGit) to local directory
-* Run c:\python27\python.exe setup.py install (or develop)
+* Run C:\\python27\\python.exe setup.py install (or develop)
 
 How to install (Debian-Ubuntu)
 ------------------------------


### PR DESCRIPTION
In Markdown single backslash was not displayed
