### PR TITLE
decrypt_keyvalue in cmdtr.py takes value in hex from command line

### DIFF
--- a/cmdtr.py
+++ b/cmdtr.py
@@ -174,7 +174,7 @@ class Commands(object):
 
     def decrypt_keyvalue(self, args):
         address_n = self.client.expand_path(args.n)
-        ret = self.client.decrypt_keyvalue(address_n, args.key, args.value)
+        ret = self.client.decrypt_keyvalue(address_n, args.key, args.value.decode("hex"))
         return ret
 
     def firmware_update(self, args):


### PR DESCRIPTION
It's much more practical to take hex input from command line than to use raw ciphertext bytes.
