### PR TITLE
Insight tx fixes

### DIFF
--- a/trezorlib/tx_api.py
+++ b/trezorlib/tx_api.py
@@ -84,7 +84,7 @@ def insight_tx(url, rawdata=False):
 
     for vout in data['vout']:
         o = t.bin_outputs.add()
-        o.amount = int(Decimal(vout['value']) * 100000000)
+        o.amount = int(Decimal(str(vout['value'])) * 100000000)
         asm = vout['scriptPubKey']['asm'].split(' ')
         asm = [ opcode_serialize(x) for x in asm ]
         o.script_pubkey = ''.join(asm)

--- a/trezorlib/tx_api.py
+++ b/trezorlib/tx_api.py
@@ -52,12 +52,15 @@ def opcode_serialize(opcode):
     except:
         raise Exception('Unknown script opcode: %s' % opcode)
 
-def insight_tx(url):
-    try:
-        f = urllib2.urlopen(url)
-    except:
-        raise Exception('URL error: %s' % url)
-    data = json.load(f)
+def insight_tx(url, rawdata=False):
+    if not rawdata:
+        try:
+            f = urllib2.urlopen(url)
+            data = json.load(f)
+        except:
+            raise Exception('URL error: %s' % url)
+    else:
+        data = url
 
     t = proto_types.TransactionType()
     t.version = data['version']


### PR DESCRIPTION
This PR includes two changes I needed to apply for my use:
- The insight_url() call assumes, as the name implies, a url. But I use my own backend which is jsonrpc based so I'm using my own TXAPI class that calls that and then delegates the result to insight_url as a dict object. No sense in redoing the good work already applied to tx_api, right? :)
- Doing Decimal(float_value) is a recipe for disaster as rounding errors are almost certain, at least in OSX and python 2.7.x, which is my work environment. Coercing the float value into a string before making a Decimal out of it completely prevents the rounding issues.