### PR TITLE
Use right URL for bridge and keep-alive connection

### DIFF
--- a/trezorlib/transport_bridge.py
+++ b/trezorlib/transport_bridge.py
@@ -7,7 +7,7 @@ import mapping
 from transport import Transport
 import messages_pb2 as proto
 
-TREZORD_HOST = 'http://localhost:21324'
+TREZORD_HOST = 'https://localback.net:21324'
 CONFIG_URL = 'https://mytrezor.com/data/plugin/config_signed.bin'
 
 def get_error(resp):
@@ -22,11 +22,13 @@ class BridgeTransport(Transport):
 
         config = r.text
 
-        r = requests.post(TREZORD_HOST + '/configure', data=config)
+        self.conn = requests.Session();
+
+        r = self.conn.post(TREZORD_HOST + '/configure', data=config, verify=None)
         if r.status_code != 200:
             raise Exception('trezord: Could not configure' + get_error(r))
 
-        r = requests.get(TREZORD_HOST + '/enumerate')
+        r = self.conn.get(TREZORD_HOST + '/enumerate', verify=None)
         if r.status_code != 200:
             raise Exception('trezord: Could not enumerate devices' + get_error(r))
         enum = r.json()
@@ -41,14 +43,14 @@ class BridgeTransport(Transport):
         super(BridgeTransport, self).__init__(device, *args, **kwargs)
 
     def _open(self):
-        r = requests.post(TREZORD_HOST + '/acquire/%s' % self.path)
+        r = self.conn.post(TREZORD_HOST + '/acquire/%s' % self.path, verify=None)
         if r.status_code != 200:
             raise Exception('trezord: Could not acquire session' + get_error(r))
         resp = r.json()
         self.session = resp['session']
 
     def _close(self):
-        r = requests.post(TREZORD_HOST + '/release/%s' % self.session)
+        r = self.conn.post(TREZORD_HOST + '/release/%s' % self.session, verify=None)
         if r.status_code != 200:
             raise Exception('trezord: Could not release session' + get_error(r))
         else:
@@ -61,7 +63,7 @@ class BridgeTransport(Transport):
         cls = protobuf_msg.__class__.__name__
         msg = protobuf_json.pb2json(protobuf_msg)
         payload = '{"type": "%s", "message": %s}' % (cls, json.dumps(msg))
-        r = requests.post(TREZORD_HOST + '/call/%s' % self.session, data=payload)
+        r = self.conn.post(TREZORD_HOST + '/call/%s' % self.session, data=payload, verify=None)
         if r.status_code != 200:
             raise Exception('trezord: Could not write message' + get_error(r))
         else:


### PR DESCRIPTION
The bridge is using https with a certificate signed for localback.net.

Use a session object (self.conn) to keep connection alive and
prevent costly ssl handshakes for every call.