### PR TITLE
Update hashbang to use /usr/bin/env python

### DIFF
--- a/tools/encfs_aes_getpass.py
+++ b/tools/encfs_aes_getpass.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 Use Trezor as a hardware key for opening EncFS filesystem!


### PR DESCRIPTION
Please use the /usr/bin/env python hashbang in order to properly detect alternative python installations (like those installed through homebrew on a mac).