### PR TITLE
Update hashbang to use /usr/bin/env python

### DIFF
--- a/helloworld.py
+++ b/helloworld.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from trezorlib.client import TrezorClient
 from trezorlib.transport_hid import HidTransport


### PR DESCRIPTION
Please use the /usr/bin/env python hashbang in order to properly detect alternative python installations (like those installed through homebrew on a mac).