### PR TITLE
Ethereum: Allow leading 0x in data. Handle new contracts.

### DIFF
--- a/trezorctl
+++ b/trezorctl
@@ -120,9 +120,6 @@ class Commands(object):
         from ethjsonrpc.utils import hex_to_dec
         import rlp
 
-        if not args.to:
-            raise Exception("Please provide to address in hex format")
-
         value = args.value
         if ' ' in value:
             value, unit = value.split(' ', 1)
@@ -145,6 +142,8 @@ class Commands(object):
 
         gas_price = eth.eth_gasPrice()
         gas_limit = args.gas
+        if args.data.startswith('0x'):
+            args.data = args.data[2:]
         data = binascii.unhexlify(args.data)
         if not gas_limit:
             gas_limit = hex_to_dec(eth.eth_estimateGas(
@@ -164,7 +163,7 @@ class Commands(object):
             data=data)
 
         transaction = rlp.encode(
-            (nonce, gas_price, gas_limit, hex_to_dec(args.to), value, data) + sig)
+            (nonce, gas_price, gas_limit, to_address, value, data) + sig)
         tx_hex = '0x%s' % binascii.hexlify(transaction)
 
         if args.publish:

--- a/trezorlib/client.py
+++ b/trezorlib/client.py
@@ -440,8 +440,10 @@ class ProtocolMixin(object):
                 nonce=int_to_big_endian(nonce),
                 gas_price=int_to_big_endian(gas_price),
                 gas_limit=int_to_big_endian(gas_limit),
-                to=to,
                 value=int_to_big_endian(value))
+
+            if to:
+                msg.to = to
 
             if data:
                 msg.data_length = len(data)


### PR DESCRIPTION
Use `0x` or `""` as destination to create a new contract.
Leading 0x in data is just ignored (data must always be given in hex).

This also fixes the case where address starts with 0x00.

Known problem: estimateGas doesn't work for new contracts.  This may be a problem with ethjsonrpc.  As a workaround, always specify gas limit for new contract.