### PR TITLE
Avoid repeating keyword argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     scripts = ['trezorctl'],
     test_suite='tests',
-    install_requires=['ecdsa>=0.9', 'protobuf>=2.6.1', 'mnemonic>=0.8', 'hidapi>=0.7.99'],
+    install_requires=['ecdsa>=0.9', 'protobuf>=2.6.1', 'mnemonic>=0.8', 'hidapi>=0.7.99', 'setuptools>=19.0'],
     include_package_data=True,
     zip_safe=False,
     classifiers=[
@@ -38,5 +38,4 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: MacOS :: MacOS X',
     ],
-    install_requires = ['setuptools>=19.0'],
 )


### PR DESCRIPTION
Repeating the keyword argument breaks package build with the following error: "SyntaxError: keyword argument" repeated