### PR TITLE
Added support for signing Ethereum transactions without node connection

### DIFF
--- a/trezorctl
+++ b/trezorctl
@@ -149,29 +149,59 @@ class Commands(object):
         else:
             value = int(value)
 
+        gas_price = args.gas_price
+        if gas_price:
+            if ' ' in gas_price:
+                gas_price, unit = gas_price.split(' ', 1)
+                if unit.lower() not in ether_units:
+                    raise CallException(types.Failure_Other, "Unrecognized gas price unit %r" % unit)
+                gas_price = int(gas_price) * ether_units[unit.lower()]
+            else:
+                gas_price = int(gas_price)
+
+        gas_limit = args.gas
+        if gas_limit:
+            gas_limit = int(gas_limit)
+
         if args.to.startswith('0x') or args.to.startswith('0X'):
             to_address = args.to[2:].decode('hex')
         else:
             to_address = args.to.decode('hex')
 
+        nonce = args.nonce
+        if nonce:
+            nonce = int(nonce)
+
         address_n = self.client.expand_path(args.n)
         address = "0x%s" % (binascii.hexlify(self.client.ethereum_get_address(address_n)),)
 
-        host, port = args.host.split(':')
-        eth = EthJsonRpc(host, int(port))
+        if not gas_price or not gas_limit or not nonce or args.data:
+            host, port = args.host.split(':')
+            eth = EthJsonRpc(host, int(port))
 
-        gas_price = eth.eth_gasPrice()
-        gas_limit = args.gas
         if args.data.startswith('0x'):
             args.data = args.data[2:]
         data = binascii.unhexlify(args.data)
-        if not gas_limit:
+
+        if not gas_price:
+            gas_price = eth.eth_gasPrice()
+
+        if args.data:
             gas_limit = hex_to_dec(eth.eth_estimateGas(
                 to_address=args.to,
                 from_address=address,
                 value=value,
                 data="0x"+args.data))
-        nonce = eth.eth_getTransactionCount(address)
+
+        if not nonce:
+            nonce = eth.eth_getTransactionCount(address)
+
+        print('from', address)
+        print('to', args.to)
+        print('value', value, 'wei')
+        print('gas_price', gas_price, 'wei')
+        print('gas_limit', gas_limit, 'gas')
+        print('nonce', nonce)
 
         sig = self.client.ethereum_sign_tx(
             n=address_n,
@@ -386,7 +416,9 @@ class Commands(object):
         (('-a', '--host'), {'type': str, 'default': 'localhost:8545'}),
         (('-n', '-address'), {'type': str}),
         (('-v', '--value'), {'type': str, 'default': "0"}),
-        (('-g', '--gas'), {'type': int}),
+        (('-g', '--gas'), {'type': int, 'help': 'Required for offline signing'}),
+        (('-t', '--gas-price'), {'type': str, 'help': 'Required for offline signing' }),
+        (('-i', '--nonce'), {'type': str, 'help': 'Required for offline signing'}),
         (('-d', '--data'), {'type': str, 'default': ''}),
         (('-p', '--publish'), {'action': 'store_true', 'default': False}),
         (('to',), {'type': str}),

--- a/trezorctl
+++ b/trezorctl
@@ -196,13 +196,6 @@ class Commands(object):
         if not nonce:
             nonce = eth.eth_getTransactionCount(address)
 
-        print('from', address)
-        print('to', args.to)
-        print('value', value, 'wei')
-        print('gas_price', gas_price, 'wei')
-        print('gas_limit', gas_limit, 'gas')
-        print('nonce', nonce)
-
         sig = self.client.ethereum_sign_tx(
             n=address_n,
             nonce=nonce,


### PR DESCRIPTION
I just added some more parameters to the command line client in order to allow custom gas price and manually specifying other parameters (like the nonce) so there is no need to connect to an Ethereum node in order to create the signed transaction.

This is very useful in combination with myetherwallet as you can relay the transaction directly there:

**Instructions:**
Get your trezor ethereum address:
```
trezorctl ethereum_get_address
```

**Send ether**
1. Invoke trezorctl specifying all parameters for offline signing:
 ```
trezorctl ethereum_sign_tx -v '185047 szabo' -g 21000 -t '18 gwei' -i 2 0x45bCD6F98B77E44A812A8CdbBf2642C9dC9403a2
```

Please note the nonce parameter (-i 2) which is the transaction number for that address. You can check the value by adding one to the nonce of the last sent transaction from your trezor address (use a block explorer to check). If is the first transaction you are executing, it should be 0, then 1, 2, 3, etc.
 
2. Enter your PIN and passphrase
3. Copy the Raw Signed Transaction string to the clipboard
4. Go to https://www.myetherwallet.com/#offline-transaction and paste the raw transaction at the end of the page (_Step 3: Send / Publish Transaction_).
5. Click **Send Transaction**