### PR TITLE
Make ScrambledWords default recovery method

### DIFF
--- a/trezorlib/client.py
+++ b/trezorlib/client.py
@@ -812,7 +812,7 @@ class ProtocolMixin(object):
 
     @field('message')
     @expect(proto.Success)
-    def recovery_device(self, word_count, passphrase_protection, pin_protection, label, language, type=types.RecoveryDeviceType_Matrix):
+    def recovery_device(self, word_count, passphrase_protection, pin_protection, label, language, type=types.RecoveryDeviceType_ScrambledWords):
         if self.features.initialized:
             raise Exception("Device is initialized already. Call wipe_device() and try again.")
 


### PR DESCRIPTION
For backwards compatibility, existing code should use the old recovery
method unless it explicitly states that it is compatible to the new
one.