### PR TITLE
Allow testing recovery with an initialized device

### DIFF
--- a/trezorctl
+++ b/trezorctl
@@ -277,7 +277,7 @@ class Commands(object):
                     'matrix':    types.RecoveryDeviceType_Matrix }
         return self.client.recovery_device(args.words, args.passphrase_protection,
                                            args.pin_protection, args.label, 'english',
-                                           typemap[args.type], args.expand)
+                                           typemap[args.type], args.expand, args.dry_run)
 
     def load_device(self, args):
         if not args.mnemonic and not args.xprv:
@@ -474,6 +474,7 @@ class Commands(object):
         (('-r', '--passphrase-protection'), {'action': 'store_true', 'default': False}),
         (('-l', '--label'), {'type': str, 'default': ''}),
         (('-t', '--type'), {'type': str, 'choices': ['scrambled', 'matrix'], 'default': 'scrambled'}),
+        (('-d', '--dry-run'), {'action': 'store_true', 'default': False}),
     )
 
     load_device.arguments = (

--- a/trezorlib/client.py
+++ b/trezorlib/client.py
@@ -830,8 +830,8 @@ class ProtocolMixin(object):
 
     @field('message')
     @expect(proto.Success)
-    def recovery_device(self, word_count, passphrase_protection, pin_protection, label, language, type=types.RecoveryDeviceType_ScrambledWords, expand=False):
-        if self.features.initialized:
+    def recovery_device(self, word_count, passphrase_protection, pin_protection, label, language, type=types.RecoveryDeviceType_ScrambledWords, expand=False, dry_run=False):
+        if self.features.initialized and not dry_run:
             raise Exception("Device is initialized already. Call wipe_device() and try again.")
 
         if word_count not in (12, 18, 24):
@@ -850,7 +850,8 @@ class ProtocolMixin(object):
                                    label=label,
                                    language=language,
                                    enforce_wordlist=True,
-                                   type=type))
+                                   type=type,
+                                   dry_run=dry_run))
 
         self.init_device()
         return res


### PR DESCRIPTION
This would allow safe mnemonic validation by using a dry-run flag (following https://github.com/trezor/trezor-mcu/issues/59).

**NOTE**: this PR requires re-generating protobuf-related code after trezor/trezor-common#33 is merged.