### PR TITLE
Updated segwit_native tests to bech32 and python3

### DIFF
--- a/tests/device_tests/test_msg_getaddress_segwit_native.py
+++ b/tests/device_tests/test_msg_getaddress_segwit_native.py
@@ -10,20 +10,20 @@ class TestMsgGetaddressSegwitNative(common.TrezorTest):
         self.setup_mnemonic_allallall()
         self.assertEqual(self.client.get_address("Testnet", self.client.expand_path("49'/1'/0'/0/0"),
                                                  True, None, script_type=proto_types.SPENDWITNESS),
-                         'QWywnqNMsMNavbCgMYiQLa91ApvsVRoaqt1i')
+                         'tb1qqzv60m9ajw8drqulta4ld4gfx0rdh82un5s65s')
         self.assertEqual(self.client.get_address("Testnet", self.client.expand_path("49'/1'/0'/1/0"),
                                                  False, None, script_type=proto_types.SPENDWITNESS),
-                         'QWzGpyMkAEvmkSVprBzRRVQMP6UPp17q4kQn')
+                         'tb1q694ccp5qcc0udmfwgp692u2s2hjpq5h407urtu')
         self.assertEqual(self.client.get_address("Testnet", self.client.expand_path("44'/1'/0'/0/0"),
                                                  False, None, script_type=proto_types.SPENDWITNESS),
-                         'QWzCpc1NeTN7hNDzK9sQQ9yrTQP8zh5Hef5J')
+                         'tb1q54un3q39sf7e7tlfq99d6ezys7qgc62a6rxllc')
         self.assertEqual(self.client.get_address("Testnet", self.client.expand_path("44'/1'/0'/0/0"),
                                                  False, None, script_type=proto_types.SPENDADDRESS),
                          'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q')
 
     def test_show_multisig_3(self):
         self.setup_mnemonic_allallall()
-        nodes = map(lambda index: self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)), range(1, 4))
+        nodes = [self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)) for index in range(1, 4)]
         multisig1 = proto_types.MultisigRedeemScriptType(
             pubkeys=map(lambda n: proto_types.HDNodePathType(node=bip32.deserialize(n.xpub), address_n=[2, 0]), nodes),
             signatures=[b'', b'', b''],
@@ -37,7 +37,7 @@ class TestMsgGetaddressSegwitNative(common.TrezorTest):
         for i in [1, 2, 3]:
             self.assertEqual(self.client.get_address("Testnet", self.client.expand_path("999'/1'/%d'/2/1" % i),
                                                      False, multisig2, script_type=proto_types.SPENDWITNESS),
-                             'T7nZJt6QbGJy6Hok4EF2LqtJPcT7z7VFSrSysGS3tEqCfDPwizqy4')
+                             'tb1qch62pf820spe9mlq49ns5uexfnl6jzcezp7d328fw58lj0rhlhasge9hzy')
             self.assertEqual(self.client.get_address("Testnet", self.client.expand_path("999'/1'/%d'/2/0" % i),
                                                      False, multisig1, script_type=proto_types.SPENDWITNESS),
-                             'T7nY3A3kewpDKumsdhonP4TBDfTXFSc2RNhZxkqmeeszRDHjM5yUn')
+                             'tb1qr6xa5v60zyt3ry9nmfew2fk5g9y3gerkjeu6xxdz7qga5kknz2ssld9z2z')

--- a/tests/device_tests/test_msg_signmessage_segwit_native.py
+++ b/tests/device_tests/test_msg_signmessage_segwit_native.py
@@ -1,0 +1,58 @@
+# This file is part of the TREZOR project.
+#
+# Copyright (C) 2012-2016 Marek Palatinus <slush@satoshilabs.com>
+# Copyright (C) 2012-2016 Pavol Rusnak <stick@satoshilabs.com>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import common
+import binascii
+
+import trezorlib.types_pb2 as proto_types
+
+
+class TestMsgSignmessage(common.TrezorTest):
+
+    def test_sign(self):
+        self.setup_mnemonic_nopin_nopassphrase()
+        sig = self.client.sign_message('Bitcoin', [0], "This is an example of a signed message.", script_type=proto_types.SPENDWITNESS)
+        self.assertEqual(sig.address, 'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j')
+        self.assertEqual(binascii.hexlify(sig.signature), b'289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80')
+
+    def test_sign_testnet(self):
+        self.setup_mnemonic_nopin_nopassphrase()
+        sig = self.client.sign_message('Testnet', [0], "This is an example of a signed message.", script_type=proto_types.SPENDWITNESS)
+        self.assertEqual(sig.address, 'tb1qyjjkmdpu7metqt5r36jf872a34syws336p3n3p')
+        self.assertEqual(binascii.hexlify(sig.signature), b'289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80')
+
+    def test_sign_long(self):
+        self.setup_mnemonic_nopin_nopassphrase()
+        sig = self.client.sign_message('Bitcoin', [0], "VeryLongMessage!" * 64, script_type=proto_types.SPENDWITNESS)
+        self.assertEqual(sig.address, 'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j')
+        self.assertEqual(binascii.hexlify(sig.signature), b'285ff795c29aef7538f8b3bdb2e8add0d0722ad630a140b6aefd504a5a895cbd867cbb00981afc50edd0398211e8d7c304bb8efa461181bc0afa67ea4a720a89ed')
+
+    def test_sign_utf(self):
+        self.setup_mnemonic_nopin_nopassphrase()
+
+        words_nfkd = u'Pr\u030ci\u0301s\u030cerne\u030c z\u030clut\u030couc\u030cky\u0301 ku\u030an\u030c u\u0301pe\u030cl d\u030ca\u0301belske\u0301 o\u0301dy za\u0301ker\u030cny\u0301 uc\u030cen\u030c be\u030cz\u030ci\u0301 pode\u0301l zo\u0301ny u\u0301lu\u030a'
+        words_nfc = u'P\u0159\xed\u0161ern\u011b \u017elu\u0165ou\u010dk\xfd k\u016f\u0148 \xfap\u011bl \u010f\xe1belsk\xe9 \xf3dy z\xe1ke\u0159n\xfd u\u010de\u0148 b\u011b\u017e\xed pod\xe9l z\xf3ny \xfal\u016f'
+
+        sig_nfkd = self.client.sign_message('Bitcoin', [0], words_nfkd, script_type=proto_types.SPENDWITNESS)
+        self.assertEqual(sig_nfkd.address, 'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j')
+        self.assertEqual(binascii.hexlify(sig_nfkd.signature), b'28d0ec02ed8da8df23e7fe9e680e7867cc290312fe1c970749d8306ddad1a1eda41c6a771b13d495dd225b13b0a9d0f915a984ee3d0703f92287bf8009fbb9f7d6')
+
+        sig_nfc = self.client.sign_message('Bitcoin', [0], words_nfc, script_type=proto_types.SPENDWITNESS)
+        self.assertEqual(sig_nfc.address, 'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j')
+        self.assertEqual(binascii.hexlify(sig_nfc.signature), b'28d0ec02ed8da8df23e7fe9e680e7867cc290312fe1c970749d8306ddad1a1eda41c6a771b13d495dd225b13b0a9d0f915a984ee3d0703f92287bf8009fbb9f7d6')

--- a/tests/device_tests/test_msg_signtx_segwit_native.py
+++ b/tests/device_tests/test_msg_signtx_segwit_native.py
@@ -39,7 +39,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
             script_type=proto_types.SPENDP2SHWITNESS,
         )
         out1 = proto_types.TxOutputType(
-            address='QWywnqNMsMNavbCgMYiQLa91ApvsVRoaqt1i',
+            address='tb1qqzv60m9ajw8drqulta4ld4gfx0rdh82un5s65s',
             amount=12300000,
             script_type=proto_types.PAYTOADDRESS,
         )
@@ -78,7 +78,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
             script_type=proto_types.SPENDP2SHWITNESS,
         )
         out1 = proto_types.TxOutputType(
-            address='QWywnqNMsMNavbCgMYiQLa91ApvsVRoaqt1i',
+            address='tb1qqzv60m9ajw8drqulta4ld4gfx0rdh82un5s65s',
             amount=12300000,
             script_type=proto_types.PAYTOADDRESS,
         )
@@ -109,7 +109,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
         self.client.set_tx_api(TxApiTestnet)
         inp1 = proto_types.TxInputType(
             address_n=self.client.expand_path("49'/1'/0'/0/0"),
-            # QWywnqNMsMNavbCgMYiQLa91ApvsVRoaqt1i
+            # tb1qqzv60m9ajw8drqulta4ld4gfx0rdh82un5s65s
             amount=12300000,
             prev_hash=binascii.unhexlify('09144602765ce3dd8f4329445b20e3684e948709c5cdcaf12da3bb079c99448a'),
             prev_index=0,
@@ -121,7 +121,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
             script_type=proto_types.PAYTOADDRESS,
         )
         out2 = proto_types.TxOutputType(
-            address='QWzGpyMkAEvmkSVprBzRRVQMP6UPp17q4kQn',
+            address='tb1q694ccp5qcc0udmfwgp692u2s2hjpq5h407urtu',
             script_type=proto_types.PAYTOADDRESS,
             amount=12300000 - 11000 - 5000000,
         )
@@ -148,7 +148,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
         self.client.set_tx_api(TxApiTestnet)
         inp1 = proto_types.TxInputType(
             address_n=self.client.expand_path("49'/1'/0'/0/0"),
-            # QWywnqNMsMNavbCgMYiQLa91ApvsVRoaqt1i
+            # tb1qqzv60m9ajw8drqulta4ld4gfx0rdh82un5s65s
             amount=12300000,
             prev_hash=binascii.unhexlify('09144602765ce3dd8f4329445b20e3684e948709c5cdcaf12da3bb079c99448a'),
             prev_index=0,
@@ -194,14 +194,14 @@ class TestMsgSigntxSegwit(common.TrezorTest):
         )
         inp2 = proto_types.TxInputType(
             address_n=self.client.expand_path("49'/1'/0'/1/0"),
-            # QWzGpyMkAEvmkSVprBzRRVQMP6UPp17q4kQn
+            # tb1q694ccp5qcc0udmfwgp692u2s2hjpq5h407urtu
             amount=7289000,
             prev_hash=binascii.unhexlify('65b811d3eca0fe6915d9f2d77c86c5a7f19bf66b1b1253c2c51cb4ae5f0c017b'),
             prev_index=1,
             script_type=proto_types.SPENDWITNESS,
         )
         out1 = proto_types.TxOutputType(
-            address='QWzCpc1NeTN7hNDzK9sQQ9yrTQP8zh5Hef5J',
+            address='tb1q54un3q39sf7e7tlfq99d6ezys7qgc62a6rxllc',
             amount=12300000,
             script_type=proto_types.PAYTOADDRESS,
         )
@@ -246,7 +246,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
     def test_send_multisig_1(self):
         self.setup_mnemonic_allallall()
         self.client.set_tx_api(TxApiTestnet)
-        nodes = map(lambda index: self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)), range(1, 4))
+        nodes = [self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)) for index in range(1, 4)]
         multisig = proto_types.MultisigRedeemScriptType(
             pubkeys=map(lambda n: proto_types.HDNodePathType(node=deserialize(n.xpub), address_n=[2, 0]), nodes),
             signatures=[b'', b'', b''],
@@ -263,7 +263,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
         )
 
         out1 = proto_types.TxOutputType(
-            address='T7nZJt6QbGJy6Hok4EF2LqtJPcT7z7VFSrSysGS3tEqCfDPwizqy4',
+            address='tb1qch62pf820spe9mlq49ns5uexfnl6jzcezp7d328fw58lj0rhlhasge9hzy',
             amount=1605000,
             script_type=proto_types.PAYTOADDRESS
         )
@@ -302,7 +302,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
     def test_send_multisig_2(self):
         self.setup_mnemonic_allallall()
         self.client.set_tx_api(TxApiTestnet)
-        nodes = map(lambda index: self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)), range(1, 4))
+        nodes = [self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)) for index in range(1, 4)]
         multisig = proto_types.MultisigRedeemScriptType(
             pubkeys=map(lambda n: proto_types.HDNodePathType(node=deserialize(n.xpub), address_n=[2, 1]), nodes),
             signatures=[b'', b'', b''],
@@ -319,7 +319,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
         )
 
         out1 = proto_types.TxOutputType(
-            address='T7nY3A3kewpDKumsdhonP4TBDfTXFSc2RNhZxkqmeeszRDHjM5yUn',
+            address='tb1qr6xa5v60zyt3ry9nmfew2fk5g9y3gerkjeu6xxdz7qga5kknz2ssld9z2z',
             amount=1604000,
             script_type=proto_types.PAYTOADDRESS
         )
@@ -358,7 +358,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
     def test_send_multisig_3_change(self):
         self.setup_mnemonic_allallall()
         self.client.set_tx_api(TxApiTestnet)
-        nodes = map(lambda index: self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)), range(1, 4))
+        nodes = [self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)) for index in range(1, 4)]
         multisig = proto_types.MultisigRedeemScriptType(
             pubkeys=map(lambda n: proto_types.HDNodePathType(node=deserialize(n.xpub), address_n=[2, 0]), nodes),
             signatures=[b'', b'', b''],
@@ -419,7 +419,7 @@ class TestMsgSigntxSegwit(common.TrezorTest):
     def test_send_multisig_4_change(self):
         self.setup_mnemonic_allallall()
         self.client.set_tx_api(TxApiTestnet)
-        nodes = map(lambda index: self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)), range(1, 4))
+        nodes = [self.client.get_public_node(self.client.expand_path("999'/1'/%d'" % index)) for index in range(1, 4)]
         multisig = proto_types.MultisigRedeemScriptType(
             pubkeys=map(lambda n: proto_types.HDNodePathType(node=deserialize(n.xpub), address_n=[1, 1]), nodes),
             signatures=[b'', b'', b''],

--- a/tests/device_tests/test_msg_verifymessage_segwit_native.py
+++ b/tests/device_tests/test_msg_verifymessage_segwit_native.py
@@ -1,0 +1,98 @@
+# This file is part of the TREZOR project.
+#
+# Copyright (C) 2012-2016 Marek Palatinus <slush@satoshilabs.com>
+# Copyright (C) 2012-2016 Pavol Rusnak <stick@satoshilabs.com>
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import common
+import binascii
+import base64
+
+
+class TestMsgVerifymessageSegwit(common.TrezorTest):
+
+    def test_message_long(self):
+        self.setup_mnemonic_nopin_nopassphrase()
+        ret = self.client.verify_message(
+            'Bitcoin',
+            'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
+            binascii.unhexlify('285ff795c29aef7538f8b3bdb2e8add0d0722ad630a140b6aefd504a5a895cbd867cbb00981afc50edd0398211e8d7c304bb8efa461181bc0afa67ea4a720a89ed'),
+            "VeryLongMessage!" * 64
+        )
+        self.assertTrue(ret)
+
+    def test_message_testnet(self):
+        self.setup_mnemonic_nopin_nopassphrase()
+        ret = self.client.verify_message(
+            'Testnet',
+            'tb1qyjjkmdpu7metqt5r36jf872a34syws336p3n3p',
+            binascii.unhexlify('289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80'),
+            'This is an example of a signed message.'
+        )
+        self.assertTrue(ret)
+
+    def test_message_verify(self):
+        self.setup_mnemonic_nopin_nopassphrase()
+
+        # trezor pubkey - OK
+        res = self.client.verify_message(
+            'Bitcoin',
+            'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
+            binascii.unhexlify('289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80'),
+            'This is an example of a signed message.'
+        )
+        self.assertTrue(res)
+
+        # trezor pubkey - FAIL - wrong sig
+        res = self.client.verify_message(
+            'Bitcoin',
+            'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
+            binascii.unhexlify('289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be00'),
+            'This is an example of a signed message.'
+        )
+        self.assertFalse(res)
+
+        # trezor pubkey - FAIL - wrong msg
+        res = self.client.verify_message(
+            'Bitcoin',
+            'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
+            binascii.unhexlify('289e23edf0e4e47ff1dec27f32cd78c50e74ef018ee8a6adf35ae17c7a9b0dd96f48b493fd7dbab03efb6f439c6383c9523b3bbc5f1a7d158a6af90ab154e9be80'),
+            'This is an example of a signed message!'
+        )
+        self.assertFalse(res)
+
+    def test_verify_utf(self):
+        self.setup_mnemonic_nopin_nopassphrase()
+
+        words_nfkd = u'Pr\u030ci\u0301s\u030cerne\u030c z\u030clut\u030couc\u030cky\u0301 ku\u030an\u030c u\u0301pe\u030cl d\u030ca\u0301belske\u0301 o\u0301dy za\u0301ker\u030cny\u0301 uc\u030cen\u030c be\u030cz\u030ci\u0301 pode\u0301l zo\u0301ny u\u0301lu\u030a'
+        words_nfc = u'P\u0159\xed\u0161ern\u011b \u017elu\u0165ou\u010dk\xfd k\u016f\u0148 \xfap\u011bl \u010f\xe1belsk\xe9 \xf3dy z\xe1ke\u0159n\xfd u\u010de\u0148 b\u011b\u017e\xed pod\xe9l z\xf3ny \xfal\u016f'
+
+        res_nfkd = self.client.verify_message(
+            'Bitcoin',
+            'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
+            binascii.unhexlify('28d0ec02ed8da8df23e7fe9e680e7867cc290312fe1c970749d8306ddad1a1eda41c6a771b13d495dd225b13b0a9d0f915a984ee3d0703f92287bf8009fbb9f7d6'),
+            words_nfkd
+        )
+
+        res_nfc = self.client.verify_message(
+            'Bitcoin',
+            'bc1qyjjkmdpu7metqt5r36jf872a34syws33s82q2j',
+            binascii.unhexlify('28d0ec02ed8da8df23e7fe9e680e7867cc290312fe1c970749d8306ddad1a1eda41c6a771b13d495dd225b13b0a9d0f915a984ee3d0703f92287bf8009fbb9f7d6'),
+            words_nfc
+        )
+
+        self.assertTrue(res_nfkd)
+        self.assertTrue(res_nfc)


### PR DESCRIPTION
Updated addresses from base58 to bech32.

The `map(lambda..., range(1,4))` doesn't work correctly under python3.