### PR TITLE
Parse json floats as string

### DIFF
--- a/trezorlib/tx_api.py
+++ b/trezorlib/tx_api.py
@@ -32,19 +32,23 @@ class TxApi(object):
         self.network = network
         self.url = url
 
+    def get_url(self, resource, resourceid):
+        url = '%s%s/%s' % (self.url, resource, resourceid)
+        return url
+
     def fetch_json(self, resource, resourceid):
         global cache_dir
         if cache_dir:
             cache_file = '%s/%s_%s_%s.json' % (cache_dir, self.network, resource, resourceid)
             try:  # looking into cache first
-                j = json.load(open(cache_file))
+                j = json.load(open(cache_file), parse_float=str)
                 return j
             except:
                 pass
         try:
-            url = '%s%s/%s' % (self.url, resource, resourceid)
+            url = self.get_url(resource, resourceid)
             r = requests.get(url, headers={'User-agent': 'Mozilla/5.0'})
-            j = r.json()
+            j = r.json(parse_float=str)
         except:
             raise RuntimeError('URL error: %s' % url)
         if cache_dir and cache_file:
@@ -88,7 +92,7 @@ class TxApiInsight(TxApi):
 
         for vout in data['vout']:
             o = t.bin_outputs.add()
-            o.amount = int(Decimal(str(vout['value'])) * 100000000)
+            o.amount = int(Decimal(vout['value']) * 100000000)
             o.script_pubkey = binascii.unhexlify(vout['scriptPubKey']['hex'])
 
         if self.zcash:


### PR DESCRIPTION
With python-2.7 the float values are sometimes rounded to unacceptable levels, e.g. stripping the last two digits for values over 100k BTC.
This change parses floats as strings to avoid any floating point problems.

Refactored get_url out of fetch_json to make it easier to add new tx_api with a different url scheme.


Note: This will also quote values in the cache.  I consider this a feature, not a bug.  I also tried using `parse_str=Decimal` but then dump doesn't work (known problem with json library).
