### PR TITLE
 Add varying url to broadcast tx, depending on the api

### DIFF
--- a/trezorctl
+++ b/trezorctl
@@ -552,7 +552,7 @@ def sign_tx(connect, coin):
     click.echo(binascii.hexlify(serialized_tx))
     click.echo()
     click.echo('Use the following form to broadcast it to the network:')
-    click.echo(txapi.url.replace('/api/', '/tx/send'))
+    click.echo(txapi.pushtx_url)
 
 
 #

--- a/trezorlib/tx_api.py
+++ b/trezorlib/tx_api.py
@@ -155,7 +155,7 @@ class TxApiBlockCypher(TxApi):
 
         t = proto.TransactionType()
         t.version = data['ver']
-        t.lock_time = data['lock_time']
+        t.lock_time = data.get('lock_time', 0)
 
         for vin in data['inputs']:
             i = t._add_inputs()
@@ -185,5 +185,5 @@ TxApiDash = TxApiInsight(network='insight_dash', url='https://dash-bitcore1.trez
 TxApiZcash = TxApiInsight(network='insight_zcash', url='https://zec-bitcore1.trezor.io/api/', zcash=True)
 TxApiBcash = TxApiInsight(network='insight_bcash', url='https://bch-bitcore2.trezor.io/api/')
 TxApiDecredTestnet = TxApiInsight(network='insight_decred_testnet', url='https://testnet.decred.org/api/')
-TxApiDogecoin = TxApiBlockCypher(network='blockcypher_dogecoin', url='http://api.blockcypher.com/v1/doge/main/')
+TxApiDogecoin = TxApiBlockCypher(network='blockcypher_dogecoin', url='https://api.blockcypher.com/v1/doge/main/')
 TxApiSegnet = TxApiSmartbit(network='smartbit_segnet', url='https://segnet-api.smartbit.com.au/v1/blockchain/')

--- a/trezorlib/tx_api.py
+++ b/trezorlib/tx_api.py
@@ -31,6 +31,7 @@ class TxApi(object):
     def __init__(self, network, url):
         self.network = network
         self.url = url
+        self.pushtx_url = url
 
     def get_url(self, resource, resourceid):
         url = '%s%s/%s' % (self.url, resource, resourceid)
@@ -68,6 +69,7 @@ class TxApiInsight(TxApi):
     def __init__(self, network, url, zcash=None):
         super(TxApiInsight, self).__init__(network, url)
         self.zcash = zcash
+        self.pushtx_url = url.replace('/api/', '/tx/send')
 
     def get_tx(self, txhash):
 
@@ -148,6 +150,10 @@ class TxApiSmartbit(TxApi):
 
 
 class TxApiBlockCypher(TxApi):
+
+    def __init__(self, network, url, zcash=None):
+        super(TxApiBlockCypher, self).__init__(network, url)
+        self.pushtx_url = url.replace('//api.', '//live.').replace('/v1/', '/').replace('/main/', '/pushtx/')
 
     def get_tx(self, txhash):
 


### PR DESCRIPTION
Every API has different URL for sending the transaction that you get from sign_tx.
Previously, in the code, it would give correct URL only for the Insight API.
Now, it gives the correct url for BlockCypher API (Dogecoin) as well.

It is now possible to also specify the correct url for SmartBit API. Unfortunately, I was unable to find the correct API URL for them, so for SmartBit the behavior will still be the same as it was before, meaning that the URL that gets printed in the end is unlikely the one that can be used to send the transaction.
I found their URL for Bitcoin - https://www.smartbit.com.au/txs/pushtx - but it is not the coin Trezorctl uses it for.
By the way, their API which is used in the Trezorctl's code for Segnet - https://segnet-api.smartbit.com.au/v1/blockchain/ , seem to be dead.

Please let me know if the name I chose for pushtx_url is good, or if I should rename it. My other suggestions for the name were sendtx_url, or something involving "broadcast", or "relay". Also I am not finally sure if the naming style with the underscore is consistent with the style that is used in Trezorctl.
