### PR TITLE
Stellar: _xdr_read_address now returns a string

### DIFF
--- a/trezorlib/stellar.py
+++ b/trezorlib/stellar.py
@@ -283,7 +283,7 @@ def _parse_operation_bytes(unpacker):
             bump_to=unpacker.unpack_uhyper()
         )
 
-    raise ValueError("Unknown operation type: " + type)
+    raise ValueError("Unknown operation type: " + str(type))
 
 
 def _xdr_read_asset(unpacker):

--- a/trezorlib/stellar.py
+++ b/trezorlib/stellar.py
@@ -21,9 +21,10 @@ import xdrlib
 from . import messages as proto
 
 # Memo types
-MEMO_TYPE_TEXT = 0
-MEMO_TYPE_ID = 1
-MEMO_TYPE_HASH = 2
+MEMO_TYPE_NONE = 0
+MEMO_TYPE_TEXT = 1
+MEMO_TYPE_ID = 2
+MEMO_TYPE_HASH = 3
 MEMO_TYPE_RETURN = 4
 
 # Asset types
@@ -103,7 +104,7 @@ def parse_transaction_bytes(tx_bytes):
     tx.memo_type = unpacker.unpack_uint()
 
     # text
-    if tx.memo_type == MEMO_TYPE_HASH:
+    if tx.memo_type == MEMO_TYPE_TEXT:
         tx.memo_text = unpacker.unpack_string()
     # id (64-bit uint)
     if tx.memo_type == MEMO_TYPE_ID:

--- a/trezorlib/stellar.py
+++ b/trezorlib/stellar.py
@@ -62,7 +62,7 @@ def address_from_public_key(pk_bytes):
     # checksum
     final_bytes.extend(struct.pack("<H", _crc16_checksum(final_bytes)))
 
-    return base64.b32encode(final_bytes)
+    return str(base64.b32encode(final_bytes), 'utf-8')
 
 
 def address_to_public_key(address_str):

--- a/trezorlib/stellar.py
+++ b/trezorlib/stellar.py
@@ -18,7 +18,7 @@ import base64
 import struct
 import xdrlib
 
-from . import messages as proto
+from . import messages
 
 # Memo types
 MEMO_TYPE_NONE = 0
@@ -80,7 +80,7 @@ def parse_transaction_bytes(tx_bytes):
         tx - a StellarSignTx describing the transaction header
         operations - an array of protobuf message objects for each operation
     """
-    tx = proto.StellarSignTx(
+    tx = messages.StellarSignTx(
         protocol_version=1
     )
     unpacker = xdrlib.Unpacker(tx_bytes)
@@ -136,14 +136,14 @@ def _parse_operation_bytes(unpacker):
     type = unpacker.unpack_uint()
 
     if type == OP_CREATE_ACCOUNT:
-        return proto.StellarCreateAccountOp(
+        return messages.StellarCreateAccountOp(
             source_account=source_account,
             new_account=_xdr_read_address(unpacker),
             starting_balance=unpacker.unpack_hyper()
         )
 
     if type == OP_PAYMENT:
-        return proto.StellarPaymentOp(
+        return messages.StellarPaymentOp(
             source_account=source_account,
             destination_account=_xdr_read_address(unpacker),
             asset=_xdr_read_asset(unpacker),
@@ -151,7 +151,7 @@ def _parse_operation_bytes(unpacker):
         )
 
     if type == OP_PATH_PAYMENT:
-        op = proto.StellarPathPaymentOp(
+        op = messages.StellarPathPaymentOp(
             source_account=source_account,
             send_asset=_xdr_read_asset(unpacker),
             send_max=unpacker.unpack_hyper(),
@@ -168,7 +168,7 @@ def _parse_operation_bytes(unpacker):
         return op
 
     if type == OP_MANAGE_OFFER:
-        return proto.StellarManageOfferOp(
+        return messages.StellarManageOfferOp(
             source_account=source_account,
             selling_asset=_xdr_read_asset(unpacker),
             buying_asset=_xdr_read_asset(unpacker),
@@ -179,7 +179,7 @@ def _parse_operation_bytes(unpacker):
         )
 
     if type == OP_CREATE_PASSIVE_OFFER:
-        return proto.StellarCreatePassiveOfferOp(
+        return messages.StellarCreatePassiveOfferOp(
             source_account=source_account,
             selling_asset=_xdr_read_asset(unpacker),
             buying_asset=_xdr_read_asset(unpacker),
@@ -189,7 +189,7 @@ def _parse_operation_bytes(unpacker):
         )
 
     if type == OP_SET_OPTIONS:
-        op = proto.StellarSetOptionsOp(
+        op = messages.StellarSetOptionsOp(
             source_account=source_account
         )
 
@@ -234,14 +234,14 @@ def _parse_operation_bytes(unpacker):
         return op
 
     if type == OP_CHANGE_TRUST:
-        return proto.StellarChangeTrustOp(
+        return messages.StellarChangeTrustOp(
             source_account=source_account,
             asset=_xdr_read_asset(unpacker),
             limit=unpacker.unpack_uhyper()
         )
 
     if type == OP_ALLOW_TRUST:
-        op = proto.StellarAllowTrustOp(
+        op = messages.StellarAllowTrustOp(
             source_account=source_account,
             trusted_account=_xdr_read_address(unpacker),
             asset_type=unpacker.unpack_uint()
@@ -257,7 +257,7 @@ def _parse_operation_bytes(unpacker):
         return op
 
     if type == OP_ACCOUNT_MERGE:
-        return proto.StellarAccountMergeOp(
+        return messages.StellarAccountMergeOp(
             source_account=source_account,
             destination_account=_xdr_read_address(unpacker)
         )
@@ -265,7 +265,7 @@ def _parse_operation_bytes(unpacker):
     # Inflation is not implemented since anyone can submit this operation to the network
 
     if type == OP_MANAGE_DATA:
-        op = proto.StellarManageDataOp(
+        op = messages.StellarManageDataOp(
             source_account=source_account,
             key=unpacker.unpack_string(),
         )
@@ -279,7 +279,7 @@ def _parse_operation_bytes(unpacker):
     # Bump Sequence
     # see: https://github.com/stellar/stellar-core/blob/master/src/xdr/Stellar-transaction.x#L269
     if type == OP_BUMP_SEQUENCE:
-        return proto.StellarBumpSequenceOp(
+        return messages.StellarBumpSequenceOp(
             source_account=source_account,
             bump_to=unpacker.unpack_uhyper()
         )
@@ -289,7 +289,7 @@ def _parse_operation_bytes(unpacker):
 
 def _xdr_read_asset(unpacker):
     """Reads a stellar Asset from unpacker"""
-    asset = proto.StellarAssetType(
+    asset = messages.StellarAssetType(
         type=unpacker.unpack_uint()
     )
 

--- a/trezorlib/stellar.py
+++ b/trezorlib/stellar.py
@@ -303,15 +303,15 @@ def _xdr_read_asset(unpacker):
 
 
 def _xdr_read_address(unpacker):
-    """Reads a stellar address and returns the 32-byte
-    data representing the address
+    """Reads a stellar address and returns the string representing the address
+    This method assumes the encoded address is a public address (starting with G)
     """
     # First 4 bytes are the address type
     address_type = unpacker.unpack_uint()
     if address_type != 0:
         raise ValueError("Unsupported address type")
 
-    return unpacker.unpack_fopaque(32)
+    return address_from_public_key(unpacker.unpack_fopaque(32))
 
 
 def _crc16_checksum(bytes):

--- a/trezorlib/stellar.py
+++ b/trezorlib/stellar.py
@@ -157,6 +157,7 @@ def _parse_operation_bytes(unpacker):
             send_max=unpacker.unpack_hyper(),
             destination_account=_xdr_read_address(unpacker),
             destination_asset=_xdr_read_asset(unpacker),
+            destination_amount=unpacker.unpack_hyper(),
             paths=[]
         )
 

--- a/trezorlib/tests/device_tests/test_msg_stellar_sign_transaction.py
+++ b/trezorlib/tests/device_tests/test_msg_stellar_sign_transaction.py
@@ -146,7 +146,7 @@ class TestMsgStellarSignTransaction(TrezorTest):
         assert b64encode(response.signature) == b'QZIP4XKPfe4OpZtuJiyrMZBX9YBzvGpHGcngdgFfHn2kcdONreF384/pCF80xfEnGm8grKaoOnUEKxqcMKvxAA=='
 
     def test_sign_tx_set_options_op_inflation(self):
-        """Set inflation destination to GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V"""
+        """Set inflation destination"""
         self.setup_mnemonic_nopin_nopassphrase()
 
         op = proto.StellarSetOptionsOp()

--- a/trezorlib/tests/device_tests/test_msg_stellar_sign_transaction.py
+++ b/trezorlib/tests/device_tests/test_msg_stellar_sign_transaction.py
@@ -145,6 +145,18 @@ class TestMsgStellarSignTransaction(TrezorTest):
 
         assert b64encode(response.signature) == b'QZIP4XKPfe4OpZtuJiyrMZBX9YBzvGpHGcngdgFfHn2kcdONreF384/pCF80xfEnGm8grKaoOnUEKxqcMKvxAA=='
 
+    def test_sign_tx_set_options_op_inflation(self):
+        """Set inflation destination to GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V"""
+        self.setup_mnemonic_nopin_nopassphrase()
+
+        op = proto.StellarSetOptionsOp()
+        op.inflation_destination_account = 'GAFXTC5OV5XQD66T7WGOB2HUVUC3ZVJDJMBDPTVQYV3G3K7TUHC6CLBR'
+
+        tx = self._create_msg()
+        response = self.client.stellar_sign_transaction(tx, [op], self.ADDRESS_N, self.NETWORK_PASSPHRASE)
+
+        assert b64encode(response.signature) == b'dveWhKY8x7b0YqGHWH6Fo1SskxaHP11NXd2n6oHKGiv+T/LqB+CCzbmJA0tplZ+0HNPJbHD7L3Bsg/y462qLDA=='
+
     def _create_msg(self) -> proto.StellarSignTx:
         tx = proto.StellarSignTx()
         tx.protocol_version = 1

--- a/trezorlib/tests/unit_tests/test_stellar.py
+++ b/trezorlib/tests/unit_tests/test_stellar.py
@@ -15,7 +15,8 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 import base64
-from trezorlib import stellar, messages as proto
+from trezorlib import stellar
+from trezorlib import messages
 
 
 def test_stellar_parse_transaction_bytes_simple():
@@ -111,7 +112,7 @@ def test_stellar_parse_operation_bytes_create_account_simple():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarCreateAccountOp)
+    assert isinstance(op, messages.StellarCreateAccountOp)
     assert op.source_account is None
     assert op.new_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.starting_balance == 1000333000
@@ -123,7 +124,7 @@ def test_stellar_parse_operation_bytes_payment_native():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarPaymentOp)
+    assert isinstance(op, messages.StellarPaymentOp)
     assert op.source_account is None
     assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.asset.type == stellar.ASSET_TYPE_NATIVE
@@ -150,7 +151,7 @@ def test_stellar_parse_operation_bytes_payment_custom7():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarPaymentOp)
+    assert isinstance(op, messages.StellarPaymentOp)
     assert op.source_account is None
     assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.asset.type == stellar.ASSET_TYPE_ALPHA12
@@ -166,7 +167,7 @@ def test_stellar_parse_operation_bytes_path_payment_none():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarPathPaymentOp)
+    assert isinstance(op, messages.StellarPathPaymentOp)
     assert op.source_account is None
     assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
 
@@ -188,7 +189,7 @@ def test_stellar_parse_operation_bytes_path_payment_one():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarPathPaymentOp)
+    assert isinstance(op, messages.StellarPathPaymentOp)
     assert op.source_account is None
     assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
 
@@ -214,7 +215,7 @@ def test_stellar_parse_operation_bytes_manage_offer_new():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarManageOfferOp)
+    assert isinstance(op, messages.StellarManageOfferOp)
     assert op.source_account is None
 
     assert op.selling_asset.type == stellar.ASSET_TYPE_NATIVE
@@ -236,7 +237,7 @@ def test_stellar_parse_operation_bytes_passive_offer_new():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarCreatePassiveOfferOp)
+    assert isinstance(op, messages.StellarCreatePassiveOfferOp)
     assert op.source_account is None
 
     assert op.selling_asset.type == stellar.ASSET_TYPE_NATIVE
@@ -257,7 +258,7 @@ def test_stellar_parse_operation_bytes_set_options_inflation():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarSetOptionsOp)
+    assert isinstance(op, messages.StellarSetOptionsOp)
     assert op.source_account is None
 
     assert op.inflation_destination_account == b'GAFXTC5OV5XQD66T7WGOB2HUVUC3ZVJDJMBDPTVQYV3G3K7TUHC6CLBR'
@@ -269,7 +270,7 @@ def test_stellar_parse_operation_bytes_change_trust_add():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarChangeTrustOp)
+    assert isinstance(op, messages.StellarChangeTrustOp)
     assert op.source_account is None
 
     assert op.asset.type == stellar.ASSET_TYPE_ALPHA4
@@ -285,7 +286,7 @@ def test_stellar_parse_operation_bytes_allow_trust_allow():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarAllowTrustOp)
+    assert isinstance(op, messages.StellarAllowTrustOp)
     assert op.source_account is None
 
     assert op.asset_type == stellar.ASSET_TYPE_ALPHA4
@@ -300,7 +301,7 @@ def test_stellar_parse_operation_bytes_account_merge_simple():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarAccountMergeOp)
+    assert isinstance(op, messages.StellarAccountMergeOp)
     assert op.source_account is None
 
     assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
@@ -312,7 +313,7 @@ def test_stellar_parse_operation_bytes_manage_data_set_simple():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarManageDataOp)
+    assert isinstance(op, messages.StellarManageDataOp)
     assert op.source_account is None
 
     assert op.key == b'test data'
@@ -325,7 +326,7 @@ def test_stellar_parse_operation_bytes_bump_sequence_simple():
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
     op = operations[0]
 
-    assert isinstance(op, proto.StellarBumpSequenceOp)
+    assert isinstance(op, messages.StellarBumpSequenceOp)
     assert op.source_account is None
 
     assert op.bump_to == 1234567890

--- a/trezorlib/tests/unit_tests/test_stellar.py
+++ b/trezorlib/tests/unit_tests/test_stellar.py
@@ -34,6 +34,7 @@ def test_stellar_parse_transaction_bytes_simple():
     assert tx.memo_hash is None
     assert tx.num_operations == len(operations)
 
+
 def test_stellar_parse_transaction_bytes_memo_text():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAEAAAAMZXhhbXBsZSBtZW1vAAAAAQAAAAAAAAAAAAAAAF1VZCRmsYW4QxUuniGRUdvFiSAn7EAQGlF77VygMMLgAAAAADuf3sgAAAAA'
 
@@ -50,6 +51,7 @@ def test_stellar_parse_transaction_bytes_memo_text():
     assert tx.memo_hash is None
     assert tx.num_operations == len(operations)
 
+
 def test_stellar_parse_transaction_bytes_memo_id():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAIAAAAAB1vNFQAAAAEAAAAAAAAAAAAAAABdVWQkZrGFuEMVLp4hkVHbxYkgJ+xAEBpRe+1coDDC4AAAAAA7n97IAAAAAA=='
 
@@ -65,6 +67,7 @@ def test_stellar_parse_transaction_bytes_memo_id():
     assert tx.memo_id == 123456789
     assert tx.memo_hash is None
     assert tx.num_operations == len(operations)
+
 
 def test_stellar_parse_transaction_bytes_memo_hash():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAMjLtb5+r8U47tVOSsYz+PQ/ryU0gzGMnw4odB11uoRjAAAAAEAAAAAAAAAAAAAAABdVWQkZrGFuEMVLp4hkVHbxYkgJ+xAEBpRe+1coDDC4AAAAAA7n97IAAAAAA=='
@@ -83,6 +86,7 @@ def test_stellar_parse_transaction_bytes_memo_hash():
     assert base64.b64encode(tx.memo_hash) == b'Iy7W+fq/FOO7VTkrGM/j0P68lNIMxjJ8OKHQddbqEYw='
     assert tx.num_operations == len(operations)
 
+
 def test_stellar_parse_transaction_bytes_memo_return():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAQjLtb5+r8U47tVOSsYz+PQ/ryU0gzGMnw4odB11uoRjAAAAAEAAAAAAAAAAAAAAABdVWQkZrGFuEMVLp4hkVHbxYkgJ+xAEBpRe+1coDDC4AAAAAA7n97IAAAAAA=='
 
@@ -100,6 +104,7 @@ def test_stellar_parse_transaction_bytes_memo_return():
     assert base64.b64encode(tx.memo_hash) == b'Iy7W+fq/FOO7VTkrGM/j0P68lNIMxjJ8OKHQddbqEYw='
     assert tx.num_operations == len(operations)
 
+
 def test_stellar_parse_operation_bytes_create_account_simple():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAAAO5/eyAAAAAA='
 
@@ -110,6 +115,7 @@ def test_stellar_parse_operation_bytes_create_account_simple():
     assert op.source_account is None
     assert op.new_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.starting_balance == 1000333000
+
 
 def test_stellar_parse_operation_bytes_payment_native():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAAAAAAAAB3PFpgAAAAA'
@@ -123,6 +129,7 @@ def test_stellar_parse_operation_bytes_payment_native():
     assert op.asset.type == stellar.ASSET_TYPE_NATIVE
     assert op.amount == 500111000
 
+
 def test_stellar_parse_operation_bytes_payment_custom4():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAABVEVTVAAAAAAphJYCwg5YNl8SPBLYehykVQ0QzSGwrg4Y1E4+Vv1qFQAAAAAdzxaYAAAAAA=='
 
@@ -135,6 +142,7 @@ def test_stellar_parse_operation_bytes_payment_custom4():
     assert op.asset.code == b'TEST'
     assert op.asset.issuer == b'GAUYJFQCYIHFQNS7CI6BFWD2DSSFKDIQZUQ3BLQODDKE4PSW7VVBKENC'
     assert op.amount == 500111000
+
 
 def test_stellar_parse_operation_bytes_payment_custom7():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAACU0VWRU5YWAAAAAAAAAAAACmElgLCDlg2XxI8Eth6HKRVDRDNIbCuDhjUTj5W/WoVAAAAAB3PFpgAAAAA'
@@ -150,6 +158,7 @@ def test_stellar_parse_operation_bytes_payment_custom7():
     assert op.asset.code == b'SEVENXX\x00\x00\x00\x00\x00'
     assert op.asset.issuer == b'GAUYJFQCYIHFQNS7CI6BFWD2DSSFKDIQZUQ3BLQODDKE4PSW7VVBKENC'
     assert op.amount == 500111000
+
 
 def test_stellar_parse_operation_bytes_path_payment_none():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAIAAAAAAAAAAHfOKn8AAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAABSlBZAAAAAADE+xa3Eb3cy85WSdqgwnUtC6UDwrC41YDANuCqe8vGxgAAAAAL68IBAAAAAAAAAAA='
@@ -171,6 +180,7 @@ def test_stellar_parse_operation_bytes_path_payment_none():
     assert op.destination_asset.issuer == b'GDCPWFVXCG65ZS6OKZE5VIGCOUWQXJIDYKYLRVMAYA3OBKT3ZPDMNTIJ'
 
     assert len(op.paths) == 0
+
 
 def test_stellar_parse_operation_bytes_path_payment_one():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAIAAAAAAAAAAHfOKn8AAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAABSlBZAAAAAADE+xa3Eb3cy85WSdqgwnUtC6UDwrC41YDANuCqe8vGxgAAAAAL68IBAAAAAQAAAAFQVEgxAAAAAMz/d9fJ3rFifblw3jT7sRZv/Ja+fqLfob//aLZQRQibAAAAAA=='
@@ -197,6 +207,7 @@ def test_stellar_parse_operation_bytes_path_payment_one():
     assert op.paths[0].code == b'PTH1'
     assert op.paths[0].issuer == b'GDGP656XZHPLCYT5XFYN4NH3WELG77EWXZ7KFX5BX77WRNSQIUEJXAJK'
 
+
 def test_stellar_parse_operation_bytes_manage_offer_new():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAMAAAAAAAAAAVVTRAAAAAAABkAD8fq0d+bofA1LCatUL0dCTJexnyYYd4Y1ghnNUXMAAAAAdzWUAAAKSzYAD0JAAAAAAAAAAAAAAAAA'
 
@@ -216,7 +227,8 @@ def test_stellar_parse_operation_bytes_manage_offer_new():
     assert op.amount == 2000000000
     assert op.price_n == 674614
     assert op.price_d == 1000000
-    assert op.offer_id == 0 # indicates a new offer
+    assert op.offer_id == 0  # indicates a new offer
+
 
 def test_stellar_parse_operation_bytes_passive_offer_new():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAQAAAAAAAAAAVVTRAAAAAAABkAD8fq0d+bofA1LCatUL0dCTJexnyYYd4Y1ghnNUXMAAAAAdzWUAAAKSzYAD0JAAAAAAA=='
@@ -238,6 +250,7 @@ def test_stellar_parse_operation_bytes_passive_offer_new():
     assert op.price_n == 674614
     assert op.price_d == 1000000
 
+
 def test_stellar_parse_operation_bytes_set_options_inflation():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAUAAAABAAAAAAt5i66vbwH70/2M4Oj0rQW81SNLAjfOsMV2bavzocXhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 
@@ -248,6 +261,7 @@ def test_stellar_parse_operation_bytes_set_options_inflation():
     assert op.source_account is None
 
     assert op.inflation_destination_account == b'GAFXTC5OV5XQD66T7WGOB2HUVUC3ZVJDJMBDPTVQYV3G3K7TUHC6CLBR'
+
 
 def test_stellar_parse_operation_bytes_change_trust_add():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAACkn7CoQZEWAlyO6z6VBUAddrDDR078TtLt/nP/hZJ9KQAAAAJUC+QAAAAAAA=='
@@ -264,6 +278,7 @@ def test_stellar_parse_operation_bytes_change_trust_add():
 
     assert op.limit == 10000000000
 
+
 def test_stellar_parse_operation_bytes_allow_trust_allow():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAcAAAAAZ0Me3OnxI2tuaC8qt95THF1fuB42qARTnP2ookJapQUAAAABSlBZAAAAAAEAAAAA'
 
@@ -278,6 +293,7 @@ def test_stellar_parse_operation_bytes_allow_trust_allow():
 
     assert op.trusted_account == b'GBTUGHW45HYSG23ONAXSVN66KMOF2X5YDY3KQBCTTT62RISCLKSQLYF4'
 
+
 def test_stellar_parse_operation_bytes_account_merge_simple():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAgAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAAA'
 
@@ -288,6 +304,7 @@ def test_stellar_parse_operation_bytes_account_merge_simple():
     assert op.source_account is None
 
     assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+
 
 def test_stellar_parse_operation_bytes_manage_data_set_simple():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAoAAAAJdGVzdCBkYXRhAAAAAAAAAQAAAARhc2RmAAAAAA=='
@@ -300,6 +317,7 @@ def test_stellar_parse_operation_bytes_manage_data_set_simple():
 
     assert op.key == b'test data'
     assert op.value == b'asdf'
+
 
 def test_stellar_parse_operation_bytes_bump_sequence_simple():
     b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAsAAAAASZYC0gAAAAA='

--- a/trezorlib/tests/unit_tests/test_stellar.py
+++ b/trezorlib/tests/unit_tests/test_stellar.py
@@ -1,0 +1,313 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2012-2018 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+import base64
+from trezorlib import stellar, messages as proto
+
+
+def test_stellar_parse_transaction_bytes_simple():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAAAO5/eyAAAAAA='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+
+    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.fee == 100
+    assert tx.sequence_number == 4294967296
+    assert tx.timebounds_start is None
+    assert tx.timebounds_end is None
+    assert tx.memo_type == stellar.MEMO_TYPE_NONE
+    assert tx.memo_text is None
+    assert tx.memo_id is None
+    assert tx.memo_hash is None
+    assert tx.num_operations == len(operations)
+
+def test_stellar_parse_transaction_bytes_memo_text():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAEAAAAMZXhhbXBsZSBtZW1vAAAAAQAAAAAAAAAAAAAAAF1VZCRmsYW4QxUuniGRUdvFiSAn7EAQGlF77VygMMLgAAAAADuf3sgAAAAA'
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+
+    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.fee == 100
+    assert tx.sequence_number == 4294967296
+    assert tx.timebounds_start is None
+    assert tx.timebounds_end is None
+    assert tx.memo_type == stellar.MEMO_TYPE_TEXT
+    assert tx.memo_text == b'example memo'
+    assert tx.memo_id is None
+    assert tx.memo_hash is None
+    assert tx.num_operations == len(operations)
+
+def test_stellar_parse_transaction_bytes_memo_id():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAIAAAAAB1vNFQAAAAEAAAAAAAAAAAAAAABdVWQkZrGFuEMVLp4hkVHbxYkgJ+xAEBpRe+1coDDC4AAAAAA7n97IAAAAAA=='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+
+    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.fee == 100
+    assert tx.sequence_number == 4294967296
+    assert tx.timebounds_start is None
+    assert tx.timebounds_end is None
+    assert tx.memo_type == stellar.MEMO_TYPE_ID
+    assert tx.memo_text is None
+    assert tx.memo_id == 123456789
+    assert tx.memo_hash is None
+    assert tx.num_operations == len(operations)
+
+def test_stellar_parse_transaction_bytes_memo_hash():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAMjLtb5+r8U47tVOSsYz+PQ/ryU0gzGMnw4odB11uoRjAAAAAEAAAAAAAAAAAAAAABdVWQkZrGFuEMVLp4hkVHbxYkgJ+xAEBpRe+1coDDC4AAAAAA7n97IAAAAAA=='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+
+    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.fee == 100
+    assert tx.sequence_number == 4294967296
+    assert tx.timebounds_start is None
+    assert tx.timebounds_end is None
+    assert tx.memo_type == stellar.MEMO_TYPE_HASH
+    assert tx.memo_text is None
+    assert tx.memo_id is None
+    # base-64 encoding of the raw bytes of sha256('stellar')
+    assert base64.b64encode(tx.memo_hash) == b'Iy7W+fq/FOO7VTkrGM/j0P68lNIMxjJ8OKHQddbqEYw='
+    assert tx.num_operations == len(operations)
+
+def test_stellar_parse_transaction_bytes_memo_return():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAQjLtb5+r8U47tVOSsYz+PQ/ryU0gzGMnw4odB11uoRjAAAAAEAAAAAAAAAAAAAAABdVWQkZrGFuEMVLp4hkVHbxYkgJ+xAEBpRe+1coDDC4AAAAAA7n97IAAAAAA=='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+
+    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.fee == 100
+    assert tx.sequence_number == 4294967296
+    assert tx.timebounds_start is None
+    assert tx.timebounds_end is None
+    assert tx.memo_type == stellar.MEMO_TYPE_RETURN
+    assert tx.memo_text is None
+    assert tx.memo_id is None
+    # base-64 encoding of the raw bytes of sha256('stellar')
+    assert base64.b64encode(tx.memo_hash) == b'Iy7W+fq/FOO7VTkrGM/j0P68lNIMxjJ8OKHQddbqEYw='
+    assert tx.num_operations == len(operations)
+
+def test_stellar_parse_operation_bytes_create_account_simple():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAAAO5/eyAAAAAA='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarCreateAccountOp)
+    assert op.source_account is None
+    assert op.new_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.starting_balance == 1000333000
+
+def test_stellar_parse_operation_bytes_payment_native():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAAAAAAAAB3PFpgAAAAA'
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarPaymentOp)
+    assert op.source_account is None
+    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.asset.type == stellar.ASSET_TYPE_NATIVE
+    assert op.amount == 500111000
+
+def test_stellar_parse_operation_bytes_payment_custom4():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAABVEVTVAAAAAAphJYCwg5YNl8SPBLYehykVQ0QzSGwrg4Y1E4+Vv1qFQAAAAAdzxaYAAAAAA=='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert op.source_account is None
+    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.asset.type == stellar.ASSET_TYPE_ALPHA4
+    assert op.asset.code == b'TEST'
+    assert op.asset.issuer == b'GAUYJFQCYIHFQNS7CI6BFWD2DSSFKDIQZUQ3BLQODDKE4PSW7VVBKENC'
+    assert op.amount == 500111000
+
+def test_stellar_parse_operation_bytes_payment_custom7():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAACU0VWRU5YWAAAAAAAAAAAACmElgLCDlg2XxI8Eth6HKRVDRDNIbCuDhjUTj5W/WoVAAAAAB3PFpgAAAAA'
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarPaymentOp)
+    assert op.source_account is None
+    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.asset.type == stellar.ASSET_TYPE_ALPHA12
+    # asset codes are either 4 or 12 characters, so this will be null-padded at the end
+    assert op.asset.code == b'SEVENXX\x00\x00\x00\x00\x00'
+    assert op.asset.issuer == b'GAUYJFQCYIHFQNS7CI6BFWD2DSSFKDIQZUQ3BLQODDKE4PSW7VVBKENC'
+    assert op.amount == 500111000
+
+def test_stellar_parse_operation_bytes_path_payment_none():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAIAAAAAAAAAAHfOKn8AAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAABSlBZAAAAAADE+xa3Eb3cy85WSdqgwnUtC6UDwrC41YDANuCqe8vGxgAAAAAL68IBAAAAAAAAAAA='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarPathPaymentOp)
+    assert op.source_account is None
+    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+
+    assert op.send_asset.type == stellar.ASSET_TYPE_NATIVE
+    assert op.send_max == 2009999999
+
+    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_asset.type == stellar.ASSET_TYPE_ALPHA4
+    # asset codes are either 4 or 12 characters, so this will be null-padded at the end
+    assert op.destination_asset.code == b'JPY\x00'
+    assert op.destination_asset.issuer == b'GDCPWFVXCG65ZS6OKZE5VIGCOUWQXJIDYKYLRVMAYA3OBKT3ZPDMNTIJ'
+
+    assert len(op.paths) == 0
+
+def test_stellar_parse_operation_bytes_path_payment_one():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAIAAAAAAAAAAHfOKn8AAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAABSlBZAAAAAADE+xa3Eb3cy85WSdqgwnUtC6UDwrC41YDANuCqe8vGxgAAAAAL68IBAAAAAQAAAAFQVEgxAAAAAMz/d9fJ3rFifblw3jT7sRZv/Ja+fqLfob//aLZQRQibAAAAAA=='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarPathPaymentOp)
+    assert op.source_account is None
+    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+
+    assert op.send_asset.type == stellar.ASSET_TYPE_NATIVE
+    assert op.send_max == 2009999999
+
+    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_asset.type == stellar.ASSET_TYPE_ALPHA4
+    # asset codes are either 4 or 12 characters, so this will be null-padded at the end
+    assert op.destination_asset.code == b'JPY\x00'
+    assert op.destination_asset.issuer == b'GDCPWFVXCG65ZS6OKZE5VIGCOUWQXJIDYKYLRVMAYA3OBKT3ZPDMNTIJ'
+    assert op.destination_amount == 200000001
+
+    assert len(op.paths) == 1
+    assert op.paths[0].type == stellar.ASSET_TYPE_ALPHA4
+    assert op.paths[0].code == b'PTH1'
+    assert op.paths[0].issuer == b'GDGP656XZHPLCYT5XFYN4NH3WELG77EWXZ7KFX5BX77WRNSQIUEJXAJK'
+
+def test_stellar_parse_operation_bytes_manage_offer_new():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAMAAAAAAAAAAVVTRAAAAAAABkAD8fq0d+bofA1LCatUL0dCTJexnyYYd4Y1ghnNUXMAAAAAdzWUAAAKSzYAD0JAAAAAAAAAAAAAAAAA'
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarManageOfferOp)
+    assert op.source_account is None
+
+    assert op.selling_asset.type == stellar.ASSET_TYPE_NATIVE
+
+    assert op.buying_asset.type == stellar.ASSET_TYPE_ALPHA4
+    # asset codes are either 4 or 12 characters, so this will be null-padded at the end
+    assert op.buying_asset.code == b'USD\x00'
+    assert op.buying_asset.issuer == b'GADEAA7R7K2HPZXIPQGUWCNLKQXUOQSMS6YZ6JQYO6DDLAQZZVIXG74A'
+
+    assert op.amount == 2000000000
+    assert op.price_n == 674614
+    assert op.price_d == 1000000
+    assert op.offer_id == 0 # indicates a new offer
+
+def test_stellar_parse_operation_bytes_passive_offer_new():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAQAAAAAAAAAAVVTRAAAAAAABkAD8fq0d+bofA1LCatUL0dCTJexnyYYd4Y1ghnNUXMAAAAAdzWUAAAKSzYAD0JAAAAAAA=='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarCreatePassiveOfferOp)
+    assert op.source_account is None
+
+    assert op.selling_asset.type == stellar.ASSET_TYPE_NATIVE
+
+    assert op.buying_asset.type == stellar.ASSET_TYPE_ALPHA4
+    # asset codes are either 4 or 12 characters, so this will be null-padded at the end
+    assert op.buying_asset.code == b'USD\x00'
+    assert op.buying_asset.issuer == b'GADEAA7R7K2HPZXIPQGUWCNLKQXUOQSMS6YZ6JQYO6DDLAQZZVIXG74A'
+
+    assert op.amount == 2000000000
+    assert op.price_n == 674614
+    assert op.price_d == 1000000
+
+def test_stellar_parse_operation_bytes_set_options_inflation():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAUAAAABAAAAAAt5i66vbwH70/2M4Oj0rQW81SNLAjfOsMV2bavzocXhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarSetOptionsOp)
+    assert op.source_account is None
+
+    assert op.inflation_destination_account == b'GAFXTC5OV5XQD66T7WGOB2HUVUC3ZVJDJMBDPTVQYV3G3K7TUHC6CLBR'
+
+def test_stellar_parse_operation_bytes_change_trust_add():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAACkn7CoQZEWAlyO6z6VBUAddrDDR078TtLt/nP/hZJ9KQAAAAJUC+QAAAAAAA=='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarChangeTrustOp)
+    assert op.source_account is None
+
+    assert op.asset.type == stellar.ASSET_TYPE_ALPHA4
+    assert op.asset.code == b'USD\x00'
+    assert op.asset.issuer == b'GCSJ7MFIIGIRMAS4R3VT5FIFIAOXNMGDI5HPYTWS5X7HH74FSJ6STSGF'
+
+    assert op.limit == 10000000000
+
+def test_stellar_parse_operation_bytes_allow_trust_allow():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAcAAAAAZ0Me3OnxI2tuaC8qt95THF1fuB42qARTnP2ookJapQUAAAABSlBZAAAAAAEAAAAA'
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarAllowTrustOp)
+    assert op.source_account is None
+
+    assert op.asset_type == stellar.ASSET_TYPE_ALPHA4
+    assert op.asset_code == b'JPY\x00'
+
+    assert op.trusted_account == b'GBTUGHW45HYSG23ONAXSVN66KMOF2X5YDY3KQBCTTT62RISCLKSQLYF4'
+
+def test_stellar_parse_operation_bytes_account_merge_simple():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAgAAAAAXVVkJGaxhbhDFS6eIZFR28WJICfsQBAaUXvtXKAwwuAAAAAA'
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarAccountMergeOp)
+    assert op.source_account is None
+
+    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+
+def test_stellar_parse_operation_bytes_manage_data_set_simple():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAoAAAAJdGVzdCBkYXRhAAAAAAAAAQAAAARhc2RmAAAAAA=='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarManageDataOp)
+    assert op.source_account is None
+
+    assert op.key == b'test data'
+    assert op.value == b'asdf'
+
+def test_stellar_parse_operation_bytes_bump_sequence_simple():
+    b64 = b'AAAAABXWSL/k028ZbPtXNf/YylTNS4Iz90PyJEnefPMBzbRpAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAsAAAAASZYC0gAAAAA='
+
+    tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
+    op = operations[0]
+
+    assert isinstance(op, proto.StellarBumpSequenceOp)
+    assert op.source_account is None
+
+    assert op.bump_to == 1234567890

--- a/trezorlib/tests/unit_tests/test_stellar.py
+++ b/trezorlib/tests/unit_tests/test_stellar.py
@@ -24,7 +24,7 @@ def test_stellar_parse_transaction_bytes_simple():
 
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
 
-    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.source_account == 'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
     assert tx.fee == 100
     assert tx.sequence_number == 4294967296
     assert tx.timebounds_start is None
@@ -41,7 +41,7 @@ def test_stellar_parse_transaction_bytes_memo_text():
 
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
 
-    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.source_account == 'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
     assert tx.fee == 100
     assert tx.sequence_number == 4294967296
     assert tx.timebounds_start is None
@@ -58,7 +58,7 @@ def test_stellar_parse_transaction_bytes_memo_id():
 
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
 
-    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.source_account == 'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
     assert tx.fee == 100
     assert tx.sequence_number == 4294967296
     assert tx.timebounds_start is None
@@ -75,7 +75,7 @@ def test_stellar_parse_transaction_bytes_memo_hash():
 
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
 
-    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.source_account == 'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
     assert tx.fee == 100
     assert tx.sequence_number == 4294967296
     assert tx.timebounds_start is None
@@ -93,7 +93,7 @@ def test_stellar_parse_transaction_bytes_memo_return():
 
     tx, operations = stellar.parse_transaction_bytes(base64.b64decode(b64))
 
-    assert tx.source_account == b'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
+    assert tx.source_account == 'GAK5MSF74TJW6GLM7NLTL76YZJKM2S4CGP3UH4REJHPHZ4YBZW2GSBPW'
     assert tx.fee == 100
     assert tx.sequence_number == 4294967296
     assert tx.timebounds_start is None
@@ -114,7 +114,7 @@ def test_stellar_parse_operation_bytes_create_account_simple():
 
     assert isinstance(op, messages.StellarCreateAccountOp)
     assert op.source_account is None
-    assert op.new_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.new_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.starting_balance == 1000333000
 
 
@@ -126,7 +126,7 @@ def test_stellar_parse_operation_bytes_payment_native():
 
     assert isinstance(op, messages.StellarPaymentOp)
     assert op.source_account is None
-    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.asset.type == stellar.ASSET_TYPE_NATIVE
     assert op.amount == 500111000
 
@@ -138,10 +138,10 @@ def test_stellar_parse_operation_bytes_payment_custom4():
     op = operations[0]
 
     assert op.source_account is None
-    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.asset.type == stellar.ASSET_TYPE_ALPHA4
     assert op.asset.code == b'TEST'
-    assert op.asset.issuer == b'GAUYJFQCYIHFQNS7CI6BFWD2DSSFKDIQZUQ3BLQODDKE4PSW7VVBKENC'
+    assert op.asset.issuer == 'GAUYJFQCYIHFQNS7CI6BFWD2DSSFKDIQZUQ3BLQODDKE4PSW7VVBKENC'
     assert op.amount == 500111000
 
 
@@ -153,11 +153,11 @@ def test_stellar_parse_operation_bytes_payment_custom7():
 
     assert isinstance(op, messages.StellarPaymentOp)
     assert op.source_account is None
-    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.asset.type == stellar.ASSET_TYPE_ALPHA12
     # asset codes are either 4 or 12 characters, so this will be null-padded at the end
     assert op.asset.code == b'SEVENXX\x00\x00\x00\x00\x00'
-    assert op.asset.issuer == b'GAUYJFQCYIHFQNS7CI6BFWD2DSSFKDIQZUQ3BLQODDKE4PSW7VVBKENC'
+    assert op.asset.issuer == 'GAUYJFQCYIHFQNS7CI6BFWD2DSSFKDIQZUQ3BLQODDKE4PSW7VVBKENC'
     assert op.amount == 500111000
 
 
@@ -169,16 +169,16 @@ def test_stellar_parse_operation_bytes_path_payment_none():
 
     assert isinstance(op, messages.StellarPathPaymentOp)
     assert op.source_account is None
-    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
 
     assert op.send_asset.type == stellar.ASSET_TYPE_NATIVE
     assert op.send_max == 2009999999
 
-    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.destination_asset.type == stellar.ASSET_TYPE_ALPHA4
     # asset codes are either 4 or 12 characters, so this will be null-padded at the end
     assert op.destination_asset.code == b'JPY\x00'
-    assert op.destination_asset.issuer == b'GDCPWFVXCG65ZS6OKZE5VIGCOUWQXJIDYKYLRVMAYA3OBKT3ZPDMNTIJ'
+    assert op.destination_asset.issuer == 'GDCPWFVXCG65ZS6OKZE5VIGCOUWQXJIDYKYLRVMAYA3OBKT3ZPDMNTIJ'
 
     assert len(op.paths) == 0
 
@@ -191,22 +191,22 @@ def test_stellar_parse_operation_bytes_path_payment_one():
 
     assert isinstance(op, messages.StellarPathPaymentOp)
     assert op.source_account is None
-    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
 
     assert op.send_asset.type == stellar.ASSET_TYPE_NATIVE
     assert op.send_max == 2009999999
 
-    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
     assert op.destination_asset.type == stellar.ASSET_TYPE_ALPHA4
     # asset codes are either 4 or 12 characters, so this will be null-padded at the end
     assert op.destination_asset.code == b'JPY\x00'
-    assert op.destination_asset.issuer == b'GDCPWFVXCG65ZS6OKZE5VIGCOUWQXJIDYKYLRVMAYA3OBKT3ZPDMNTIJ'
+    assert op.destination_asset.issuer == 'GDCPWFVXCG65ZS6OKZE5VIGCOUWQXJIDYKYLRVMAYA3OBKT3ZPDMNTIJ'
     assert op.destination_amount == 200000001
 
     assert len(op.paths) == 1
     assert op.paths[0].type == stellar.ASSET_TYPE_ALPHA4
     assert op.paths[0].code == b'PTH1'
-    assert op.paths[0].issuer == b'GDGP656XZHPLCYT5XFYN4NH3WELG77EWXZ7KFX5BX77WRNSQIUEJXAJK'
+    assert op.paths[0].issuer == 'GDGP656XZHPLCYT5XFYN4NH3WELG77EWXZ7KFX5BX77WRNSQIUEJXAJK'
 
 
 def test_stellar_parse_operation_bytes_manage_offer_new():
@@ -223,7 +223,7 @@ def test_stellar_parse_operation_bytes_manage_offer_new():
     assert op.buying_asset.type == stellar.ASSET_TYPE_ALPHA4
     # asset codes are either 4 or 12 characters, so this will be null-padded at the end
     assert op.buying_asset.code == b'USD\x00'
-    assert op.buying_asset.issuer == b'GADEAA7R7K2HPZXIPQGUWCNLKQXUOQSMS6YZ6JQYO6DDLAQZZVIXG74A'
+    assert op.buying_asset.issuer == 'GADEAA7R7K2HPZXIPQGUWCNLKQXUOQSMS6YZ6JQYO6DDLAQZZVIXG74A'
 
     assert op.amount == 2000000000
     assert op.price_n == 674614
@@ -245,7 +245,7 @@ def test_stellar_parse_operation_bytes_passive_offer_new():
     assert op.buying_asset.type == stellar.ASSET_TYPE_ALPHA4
     # asset codes are either 4 or 12 characters, so this will be null-padded at the end
     assert op.buying_asset.code == b'USD\x00'
-    assert op.buying_asset.issuer == b'GADEAA7R7K2HPZXIPQGUWCNLKQXUOQSMS6YZ6JQYO6DDLAQZZVIXG74A'
+    assert op.buying_asset.issuer == 'GADEAA7R7K2HPZXIPQGUWCNLKQXUOQSMS6YZ6JQYO6DDLAQZZVIXG74A'
 
     assert op.amount == 2000000000
     assert op.price_n == 674614
@@ -261,7 +261,7 @@ def test_stellar_parse_operation_bytes_set_options_inflation():
     assert isinstance(op, messages.StellarSetOptionsOp)
     assert op.source_account is None
 
-    assert op.inflation_destination_account == b'GAFXTC5OV5XQD66T7WGOB2HUVUC3ZVJDJMBDPTVQYV3G3K7TUHC6CLBR'
+    assert op.inflation_destination_account == 'GAFXTC5OV5XQD66T7WGOB2HUVUC3ZVJDJMBDPTVQYV3G3K7TUHC6CLBR'
 
 
 def test_stellar_parse_operation_bytes_change_trust_add():
@@ -275,7 +275,7 @@ def test_stellar_parse_operation_bytes_change_trust_add():
 
     assert op.asset.type == stellar.ASSET_TYPE_ALPHA4
     assert op.asset.code == b'USD\x00'
-    assert op.asset.issuer == b'GCSJ7MFIIGIRMAS4R3VT5FIFIAOXNMGDI5HPYTWS5X7HH74FSJ6STSGF'
+    assert op.asset.issuer == 'GCSJ7MFIIGIRMAS4R3VT5FIFIAOXNMGDI5HPYTWS5X7HH74FSJ6STSGF'
 
     assert op.limit == 10000000000
 
@@ -292,7 +292,7 @@ def test_stellar_parse_operation_bytes_allow_trust_allow():
     assert op.asset_type == stellar.ASSET_TYPE_ALPHA4
     assert op.asset_code == b'JPY\x00'
 
-    assert op.trusted_account == b'GBTUGHW45HYSG23ONAXSVN66KMOF2X5YDY3KQBCTTT62RISCLKSQLYF4'
+    assert op.trusted_account == 'GBTUGHW45HYSG23ONAXSVN66KMOF2X5YDY3KQBCTTT62RISCLKSQLYF4'
 
 
 def test_stellar_parse_operation_bytes_account_merge_simple():
@@ -304,7 +304,7 @@ def test_stellar_parse_operation_bytes_account_merge_simple():
     assert isinstance(op, messages.StellarAccountMergeOp)
     assert op.source_account is None
 
-    assert op.destination_account == b'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
+    assert op.destination_account == 'GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V'
 
 
 def test_stellar_parse_operation_bytes_manage_data_set_simple():


### PR DESCRIPTION
Another minor change I found to make things compatible with the new message format that sends accounts as strings.

Also includes a bonus test for setting the inflation destination.