### PR TITLE
tests: enable Lisk tests for t1

### DIFF
--- a/trezorlib/tests/device_tests/test_msg_lisk_getaddress.py
+++ b/trezorlib/tests/device_tests/test_msg_lisk_getaddress.py
@@ -20,7 +20,6 @@ from .common import TrezorTest
 
 
 @pytest.mark.lisk
-@pytest.mark.skip_t1
 class TestMsgLiskGetaddress(TrezorTest):
 
     def test_lisk_getaddress(self):

--- a/trezorlib/tests/device_tests/test_msg_lisk_getpublickey.py
+++ b/trezorlib/tests/device_tests/test_msg_lisk_getpublickey.py
@@ -21,7 +21,6 @@ from .common import TrezorTest
 
 
 @pytest.mark.lisk
-@pytest.mark.skip_t1
 class TestMsgLiskGetPublicKey(TrezorTest):
 
     def test_lisk_get_public_key(self):

--- a/trezorlib/tests/device_tests/test_msg_lisk_signmessage.py
+++ b/trezorlib/tests/device_tests/test_msg_lisk_signmessage.py
@@ -21,7 +21,6 @@ from .common import TrezorTest
 
 
 @pytest.mark.lisk
-@pytest.mark.skip_t1
 class TestMsgLiskSignmessage(TrezorTest):
 
     def test_sign(self):

--- a/trezorlib/tests/device_tests/test_msg_lisk_signtx.py
+++ b/trezorlib/tests/device_tests/test_msg_lisk_signtx.py
@@ -25,7 +25,6 @@ PUBLIC_KEY = unhexlify('eb56d7bbb5e8ea9269405f7a8527fe126023d1db2c973cfac6f760b6
 
 
 @pytest.mark.lisk
-@pytest.mark.skip_t1
 class TestMsgLiskSignTx(TrezorTest):
 
     def test_lisk_sign_tx_send(self):

--- a/trezorlib/tests/device_tests/test_msg_lisk_verifymessage.py
+++ b/trezorlib/tests/device_tests/test_msg_lisk_verifymessage.py
@@ -22,7 +22,6 @@ from trezorlib import messages as proto
 
 
 @pytest.mark.lisk
-@pytest.mark.skip_t1
 class TestMsgLiskVerifymessage(TrezorTest):
 
     def test_verify(self):


### PR DESCRIPTION
Now when the integration for Lisk for T1 is complete tests should be run for both devices platform.
https://github.com/trezor/trezor-mcu/pull/351