### PR TITLE
qt: don't import PyQt5.Qt

### DIFF
--- a/trezorlib/qt/pinmatrix.py
+++ b/trezorlib/qt/pinmatrix.py
@@ -30,8 +30,7 @@ try:
         QHBoxLayout,
     )
     from PyQt5.QtGui import QRegExpValidator
-    from PyQt5.QtCore import QRegExp, Qt
-    from PyQt5.Qt import QT_VERSION_STR
+    from PyQt5.QtCore import QRegExp, Qt, QT_VERSION_STR
 except Exception:
     from PyQt4.QtGui import (
         QPushButton,


### PR DESCRIPTION
Apparently, `import PyQt5.Qt` imports "all of Qt".
Let's not do this please. :)

- we have "bluetooth"-related issues
- binaries created by pyinstaller are unnecessarily large

see https://github.com/spesmilo/electrum/issues/4960
