### PR TITLE
Don't require prevtx for coins with BIP-143 fork id

### DIFF
--- a/trezorlib/btc.py
+++ b/trezorlib/btc.py
@@ -91,7 +91,11 @@ def sign_tx(client, coin_name, inputs, outputs, details=None, prev_txes=None):
     # set up a transactions dict
     txes = {None: messages.TransactionType(inputs=inputs, outputs=outputs)}
     # preload all relevant transactions ahead of time
-    if not coins.by_name[coin_name]["force_bip143"]:
+    if coin_name in coins.by_name:
+        load_prevtxes = not coins.by_name[coin_name]["force_bip143"]
+    else:
+        load_prevtxes = True
+    if load_prevtxes:
         for inp in inputs:
             if inp.script_type not in (
                 messages.InputScriptType.SPENDP2SHWITNESS,

--- a/trezorlib/btc.py
+++ b/trezorlib/btc.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-from . import messages
+from . import coins, messages
 from .tools import CallException, expect, normalize_nfc, session
 
 
@@ -91,19 +91,20 @@ def sign_tx(client, coin_name, inputs, outputs, details=None, prev_txes=None):
     # set up a transactions dict
     txes = {None: messages.TransactionType(inputs=inputs, outputs=outputs)}
     # preload all relevant transactions ahead of time
-    for inp in inputs:
-        if inp.script_type not in (
-            messages.InputScriptType.SPENDP2SHWITNESS,
-            messages.InputScriptType.SPENDWITNESS,
-            messages.InputScriptType.EXTERNAL,
-        ):
-            try:
-                prev_tx = prev_txes[inp.prev_hash]
-            except Exception as e:
-                raise ValueError("Could not retrieve prev_tx") from e
-            if not isinstance(prev_tx, messages.TransactionType):
-                raise ValueError("Invalid value for prev_tx") from None
-            txes[inp.prev_hash] = prev_tx
+    if not coins.by_name[coin_name]["force_bip143"]:
+        for inp in inputs:
+            if inp.script_type not in (
+                messages.InputScriptType.SPENDP2SHWITNESS,
+                messages.InputScriptType.SPENDWITNESS,
+                messages.InputScriptType.EXTERNAL,
+            ):
+                try:
+                    prev_tx = prev_txes[inp.prev_hash]
+                except Exception as e:
+                    raise ValueError("Could not retrieve prev_tx") from e
+                if not isinstance(prev_tx, messages.TransactionType):
+                    raise ValueError("Invalid value for prev_tx") from None
+                txes[inp.prev_hash] = prev_tx
 
     if details is None:
         signtx = messages.SignTx()


### PR DESCRIPTION
Is using `coins.by_name` okay here, to check for `force_bip143`?

This is necessary to get `electron-cash` working again (plus the obvious update of the plugin in electroncash – I'm working on that).
